### PR TITLE
GeoBlacklight v3+ Support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require: rubocop-rspec
+require: rubocop-rails
 
 Rails:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,6 @@ else
   gem 'image_processing', '~> 1.6'
   gem 'mimemagic', '~> 0.3'
   gem 'statesman', '>= 3.4'
-  gem 'rails', '~> 5.2.0', '< 6'
+  gem 'rails', '>= 5.2', '< 6.2'
 end
 # END ENGINE_CART BLOCK

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ if File.exist?(file)
   end
 else
   Bundler.ui.warn "[EngineCart] Unable to find test application dependencies in #{file}, using placeholder dependencies"
-  gem 'geoblacklight', '~> 3.0'
+  gem 'geoblacklight', '>= 2.0'
   gem 'mini_magick', '~> 4.9.4'
   gem 'image_processing', '~> 1.6'
   gem 'mimemagic', '~> 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ if File.exist?(file)
   end
 else
   Bundler.ui.warn "[EngineCart] Unable to find test application dependencies in #{file}, using placeholder dependencies"
-  gem 'geoblacklight', '~> 2.0'
+  gem 'geoblacklight', '~> 3.0'
   gem 'mini_magick', '~> 4.9.4'
   gem 'image_processing', '~> 1.6'
   gem 'mimemagic', '~> 0.3'

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   # Peg simplecov to < 0.8 until this is resolved:
   # https://github.com/colszowka/simplecov/issues/281
   gem 'coveralls', require: false
-  gem 'rubocop', '0.60.0', require: false
+  gem 'rubocop', '~> 1.9', require: false
 end
 
 # To use a debugger

--- a/app/models/solr_document_sidecar.rb
+++ b/app/models/solr_document_sidecar.rb
@@ -3,7 +3,10 @@
 ##
 # Metadata for indexed documents
 class SolrDocumentSidecar < ApplicationRecord
-  include Statesman::Adapters::ActiveRecordQueries
+  include Statesman::Adapters::ActiveRecordQueries[
+    transition_class: SidecarImageTransition,
+    initial_state: :initialized
+  ]
 
   belongs_to :document, optional: false, polymorphic: true
   has_many :sidecar_image_transitions, autosave: false, dependent: :destroy

--- a/app/services/geoblacklight_sidecar_images/image_service.rb
+++ b/app/services/geoblacklight_sidecar_images/image_service.rb
@@ -41,8 +41,8 @@ module GeoblacklightSidecarImages
       end
 
       log_output
-    rescue Exception => invalid
-      @metadata['exception'] = invalid.inspect
+    rescue Exception => e
+      @metadata['exception'] = e.inspect
       @document.sidecar.image_state.transition_to!(:failed, @metadata)
 
       log_output

--- a/geoblacklight_sidecar_images.gemspec
+++ b/geoblacklight_sidecar_images.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 3.0'
   s.add_development_dependency 'rubocop', '~> 1.9'
   s.add_development_dependency 'rubocop-rspec', '~> 1.30.0'
+  s.add_development_dependency 'rubocop-rails', '~> 2.9'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'solr_wrapper', '~> 2.2'
   s.add_development_dependency 'sprockets', '< 4'

--- a/geoblacklight_sidecar_images.gemspec
+++ b/geoblacklight_sidecar_images.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner', '~> 1.3'
   s.add_development_dependency 'engine_cart', '~> 2.2'
   s.add_development_dependency 'rspec-rails', '~> 3.0'
-  s.add_development_dependency 'rubocop', '~> 0.60.0'
+  s.add_development_dependency 'rubocop', '~> 1.9'
   s.add_development_dependency 'rubocop-rspec', '~> 1.30.0'
   s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'solr_wrapper', '~> 2.2'

--- a/geoblacklight_sidecar_images.gemspec
+++ b/geoblacklight_sidecar_images.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'image_processing', '~> 1.6'
   s.add_dependency 'statesman', '>= 3.4'
   s.add_dependency 'mimemagic', '~> 0.3'
-  s.add_dependency 'rails', '>= 5.2', '< 6'
+  s.add_dependency 'rails', '>= 5.2', '< 6.2'
 
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'capybara'

--- a/geoblacklight_sidecar_images.gemspec
+++ b/geoblacklight_sidecar_images.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'geoblacklight', '~> 2.0'
+  s.add_dependency 'geoblacklight', '~> 3.0'
   s.add_dependency 'mini_magick', '~> 4.9.4'
   s.add_dependency 'image_processing', '~> 1.6'
   s.add_dependency 'statesman', '>= 3.4'

--- a/geoblacklight_sidecar_images.gemspec
+++ b/geoblacklight_sidecar_images.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'geoblacklight', '~> 3.0'
+  s.add_dependency 'geoblacklight', '>= 2.0'
   s.add_dependency 'mini_magick', '~> 4.9.4'
   s.add_dependency 'image_processing', '~> 1.6'
   s.add_dependency 'statesman', '>= 3.4'

--- a/spec/models/solr_document_sidecar_spec.rb
+++ b/spec/models/solr_document_sidecar_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe GeoblacklightSidecarImages::SolrDocumentSidecar do
+describe SolrDocumentSidecar do
   let(:document) { SolrDocument.new(document_attributes) }
 
   describe '#sidecar' do

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -11,7 +11,7 @@ class TestAppGenerator < Rails::Generators::Base
 
   def add_gems
     gem 'blacklight', '~> 7.0'
-    gem 'geoblacklight', '~> 3.0'
+    gem 'geoblacklight', '>= 3.0'
 
     Bundler.with_clean_env do
       run 'bundle install'

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -11,7 +11,7 @@ class TestAppGenerator < Rails::Generators::Base
 
   def add_gems
     gem 'blacklight', '~> 7.0'
-    gem 'geoblacklight', '~> 2.0'
+    gem 'geoblacklight', '~> 3.0'
 
     Bundler.with_clean_env do
       run 'bundle install'

--- a/template.rb
+++ b/template.rb
@@ -1,7 +1,7 @@
 # $ rails _5.2.2_ new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight_sidecar_images/master/template.rb
 
 gem 'blacklight', '>= 7.0'
-gem 'geoblacklight', '>= 2.0'
+gem 'geoblacklight', '>= 3.0'
 gem 'statesman', '>= 3.4'
 gem 'geoblacklight_sidecar_images', :git => "git://github.com/ewlarson/geoblacklight_sidecar_images.git", :branch => "master"
 

--- a/template.rb
+++ b/template.rb
@@ -1,7 +1,7 @@
 # $ rails _5.2.2_ new app-name -m https://raw.githubusercontent.com/geoblacklight/geoblacklight_sidecar_images/master/template.rb
 
 gem 'blacklight', '>= 7.0'
-gem 'geoblacklight', '>= 3.0'
+gem 'geoblacklight', '>= 2.0'
 gem 'statesman', '>= 3.4'
 gem 'geoblacklight_sidecar_images', :git => "git://github.com/ewlarson/geoblacklight_sidecar_images.git", :branch => "master"
 


### PR DESCRIPTION
This PR allows the GBLSCI gem to work with GeoBlacklight v3+ releases. Extends support for Rails 6+ too. 