### PR TITLE
Rails 7 cleanup: Fix faraday namespace, add spec for successful image harvest, add GBL rake tasks

### DIFF
--- a/.solr_wrapper.yml
+++ b/.solr_wrapper.yml
@@ -1,5 +1,6 @@
 url: https://archive.apache.org/dist/lucene/solr/8.11.1/solr-8.11.1.tgz
 validate: false
+instance_dir: tmp/solr
 download_dir: tmp/solr
 collection:
   dir: solr/conf/

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ bundle exec rake gblsci:images:harvest_all
 
 #### Harvest an individual image
 
-Allows you to add images one document id at a time.
+Allows you to add images one document id at a time. Pass a DOC_ID env var.
 
 ```bash
-bundle exec rake gblsci:images:harvest_doc_id['stanford-cz128vq0535']
+DOC_ID='stanford-cz128vq0535' bundle exec rake gblsci:images:harvest_doc_id
 ```
 
 #### Harvest all incomplete states

--- a/Rakefile
+++ b/Rakefile
@@ -29,4 +29,44 @@ task ci: ["engine_cart:generate"] do
   Rake::Task["spec"].invoke
 end
 
+namespace :geoblacklight do
+
+  namespace :internal do
+    task seed: ["engine_cart:generate"] do
+      within_test_app do
+        system "bundle exec rake gblsci:sample_data:seed"
+        system "bundle exec rake geoblacklight:downloads:mkdir"
+      end
+    end
+  end
+
+  desc "Run Solr and seed with sample data"
+  task :solr do
+    if File.exist? EngineCart.destination
+      within_test_app do
+        system "bundle update"
+      end
+    else
+      Rake::Task["engine_cart:generate"].invoke
+    end
+
+    SolrWrapper.wrap(port: "8983") do |solr|
+      solr.with_collection(name: "blacklight-core", dir: File.join(File.expand_path(".", File.dirname(__FILE__)), "solr", "conf")) do
+        Rake::Task["geoblacklight:internal:seed"].invoke
+
+        within_test_app do
+          puts "\nSolr server running: http://localhost:#{solr.port}/solr/#/blacklight-core"
+          puts "\n^C to stop"
+          puts " "
+          begin
+            sleep
+          rescue Interrupt
+            puts "Shutting down..."
+          end
+        end
+      end
+    end
+  end
+end
+
 task default: %i[rubocop ci]

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,6 @@ task ci: ["engine_cart:generate"] do
 end
 
 namespace :geoblacklight do
-
   namespace :internal do
     task seed: ["engine_cart:generate"] do
       within_test_app do

--- a/app/services/geoblacklight_sidecar_images/image_service.rb
+++ b/app/services/geoblacklight_sidecar_images/image_service.rb
@@ -57,7 +57,7 @@ module GeoblacklightSidecarImages
 
       return nil unless image_data && @metadata["placeheld"] == false
 
-      temp_file = Tempfile.new([document_id, ".tmp"])
+      temp_file = Tempfile.new("#{document_id}.tmp")
       temp_file.binmode
       temp_file.write(image_data)
       temp_file.rewind

--- a/app/services/geoblacklight_sidecar_images/image_service.rb
+++ b/app/services/geoblacklight_sidecar_images/image_service.rb
@@ -128,7 +128,7 @@ module GeoblacklightSidecarImages
       return nil unless uri.scheme.include?("http")
 
       conn = Faraday.new(url: uri.normalize.to_s) do |b|
-        b.use FaradayMiddleware::FollowRedirects
+        b.use Geoblacklight::FaradayMiddleware::FollowRedirects
         b.adapter :net_http
       end
 

--- a/geoblacklight_sidecar_images.gemspec
+++ b/geoblacklight_sidecar_images.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-rails", "~> 3.0"
   s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "simplecov", "~> 0.22"
-  s.add_development_dependency "solr_wrapper", "~> 3.1"
+  s.add_development_dependency "solr_wrapper", "~> 4.0"
   s.add_development_dependency "sprockets", "< 4"
   s.add_development_dependency "standard", "~> 1.24"
 end

--- a/lib/generators/geoblacklight_sidecar_images/config_generator.rb
+++ b/lib/generators/geoblacklight_sidecar_images/config_generator.rb
@@ -11,7 +11,16 @@ module GeoblacklightSidecarImages
        1. Copies config files to host config
     DESCRIPTION
 
-    def create_store_image_jobs
+    def set_active_storage_processor
+      app_config = <<-"APP"
+      
+        config.active_storage.variant_processor = :mini_magick
+      APP
+
+      inject_into_file "config/application.rb", app_config, after: "config.generators.system_tests = nil"
+    end
+
+    def create_statesman_initializer
       copy_file "config/initializers/statesman.rb", "config/initializers/statesman.rb"
     end
   end

--- a/lib/tasks/geoblacklight_sidecar_images_tasks.rake
+++ b/lib/tasks/geoblacklight_sidecar_images_tasks.rake
@@ -20,7 +20,7 @@ namespace :gblsci do
   namespace :images do
     desc "Harvest image for specific document"
     task harvest_doc_id: :environment do
-      GeoblacklightSidecarImages::StoreImageJob.perform_later(ENV['DOC_ID'])
+      GeoblacklightSidecarImages::StoreImageJob.perform_later(ENV["DOC_ID"])
     end
 
     desc "Harvest all images"
@@ -183,7 +183,7 @@ namespace :gblsci do
       ]
 
       states.each do |state|
-        sidecars = SolrDocumentSidecar.in_state(state).each do |sc|
+        SolrDocumentSidecar.in_state(state).each do |sc|
           puts "#{state} - #{sc.document_id} - #{sc.image_state.last_transition.metadata.inspect}"
         end
       end

--- a/lib/tasks/geoblacklight_sidecar_images_tasks.rake
+++ b/lib/tasks/geoblacklight_sidecar_images_tasks.rake
@@ -19,8 +19,8 @@ namespace :gblsci do
 
   namespace :images do
     desc "Harvest image for specific document"
-    task :harvest_doc_id, [:doc_id] => [:environment] do |_t, args|
-      GeoblacklightSidecarImages::StoreImageJob.perform_later(args[:doc_id])
+    task harvest_doc_id: :environment do
+      GeoblacklightSidecarImages::StoreImageJob.perform_later(ENV['DOC_ID'])
     end
 
     desc "Harvest all images"
@@ -183,7 +183,7 @@ namespace :gblsci do
       ]
 
       states.each do |state|
-        SolrDocumentSidecar.in_state(state).each do |sc|
+        sidecars = SolrDocumentSidecar.in_state(state).each do |sc|
           puts "#{state} - #{sc.document_id} - #{sc.image_state.last_transition.metadata.inspect}"
         end
       end

--- a/spec/fixtures/files/umn_solr_thumb.json
+++ b/spec/fixtures/files/umn_solr_thumb.json
@@ -14,7 +14,7 @@
   "layer_slug_s":"aaf63e35-3d5f-4e62-b59d-377f008e9aad",
   "dc_format_s":"TIFF",
   "dc_creator_sm":["Minnesota. Department of Highways."],
-  "thumbnail_path_ss":"https://umedia.lib.umn.edu/sites/default/files/imagecache/square300/reference/562/image/jpeg/1089695.jpg",
+  "thumbnail_path_ss":"https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll206/id/133.jpg",
   "dc_type_s":"Still image",
   "dc_identifier_s":"aaf63e35-3d5f-4e62-b59d-377f008e9aad",
   "dc_relation_sm":["http://sws.geonames.org/5037779/about/rdf"],

--- a/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
+++ b/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "spec_helper"
+require "rake"
+
+describe "geoblacklight_sidecar_images_tasks.rake" do
+  include ActiveJob::TestHelper
+
+  # @TODO
+  # gblsci:sample_data:seed
+  # gblsci:images:harvest_all
+  # gblsci:images:harvest_states
+  # gblsci:images:harvest_retry
+  # gblsci:images:harvest_report
+  # gblsci:images:harvest_purge_all
+  # gblsci:images:harvest_purge_orphans
+  # gblsci:images:harvest_destroy_batch
+  # gblsci:images:harvest_failed_state_inspect
+
+  # zsh - bundle exec rake gblsci:images:harvest_doc_id\['stanford-cz128vq0535'\]
+  describe "gblsci:images:harvest_doc_id['stanford-cz128vq0535']" do
+    before do
+      Rails.application.load_tasks
+    end
+
+    it "tasks can be invoked" do
+      # Enqueues job
+      ENV["DOC_ID"] = "princeton-sx61dn82p"
+      Rake::Task["gblsci:images:harvest_doc_id"].invoke
+      expect(enqueued_jobs.size).to eq(1)
+      
+      perform_enqueued_jobs
+
+      sd = SolrDocument.find(ENV["DOC_ID"])
+      expect(sd.sidecar.image?).to eq(true)
+    end
+  end
+end

--- a/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
+++ b/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
@@ -18,21 +18,23 @@ describe "geoblacklight_sidecar_images_tasks.rake" do
   # gblsci:images:harvest_destroy_batch
   # gblsci:images:harvest_failed_state_inspect
 
-  # zsh - bundle exec rake gblsci:images:harvest_doc_id\['stanford-cz128vq0535'\]
-  describe "gblsci:images:harvest_doc_id['stanford-cz128vq0535']" do
+  # DOC_ID='stanford-cz128vq0535' bundle exec rake gblsci:images:harvest_doc_id
+  describe "gblsci:images:harvest_doc_id" do
     before do
       Rails.application.load_tasks
     end
 
-    it "tasks can be invoked" do
-      # Enqueues job
-      ENV["DOC_ID"] = "princeton-sx61dn82p"
+    it "successfully attaches a thumbnail to a document sidecar" do
+      ENV["DOC_ID"] = "princeton-02870w62c"
       Rake::Task["gblsci:images:harvest_doc_id"].invoke
       expect(enqueued_jobs.size).to eq(1)
       
       perform_enqueued_jobs
+      sleep(2)
 
-      sd = SolrDocument.find(ENV["DOC_ID"])
+      Rake::Task["gblsci:images:harvest_states"].invoke
+
+      sd = SolrDocument.find(ENV["DOC_ID"])      
       expect(sd.sidecar.image?).to eq(true)
     end
   end

--- a/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
+++ b/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
@@ -24,18 +24,10 @@ describe "geoblacklight_sidecar_images_tasks.rake" do
       Rails.application.load_tasks
     end
 
-    it "successfully attaches a thumbnail to a document sidecar" do
+    it "enqueues background job to harvest image" do
       ENV["DOC_ID"] = "princeton-02870w62c"
       Rake::Task["gblsci:images:harvest_doc_id"].invoke
       expect(enqueued_jobs.size).to eq(1)
-
-      perform_enqueued_jobs
-      sleep(2)
-
-      Rake::Task["gblsci:images:harvest_states"].invoke
-
-      sd = SolrDocument.find(ENV["DOC_ID"])
-      expect(sd.sidecar.image?).to eq(true)
     end
   end
 end

--- a/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
+++ b/spec/lib/tasks/geoblacklight_sidecar_images_spec.rb
@@ -28,13 +28,13 @@ describe "geoblacklight_sidecar_images_tasks.rake" do
       ENV["DOC_ID"] = "princeton-02870w62c"
       Rake::Task["gblsci:images:harvest_doc_id"].invoke
       expect(enqueued_jobs.size).to eq(1)
-      
+
       perform_enqueued_jobs
       sleep(2)
 
       Rake::Task["gblsci:images:harvest_states"].invoke
 
-      sd = SolrDocument.find(ENV["DOC_ID"])      
+      sd = SolrDocument.find(ENV["DOC_ID"])
       expect(sd.sidecar.image?).to eq(true)
     end
   end

--- a/spec/services/image_service_spec.rb
+++ b/spec/services/image_service_spec.rb
@@ -19,6 +19,11 @@ describe GeoblacklightSidecarImages::ImageService do
       expect(iiif_imgsvc).to respond_to(:store)
     end
 
+    it "stores an image" do
+      iiif_imgsvc.store
+      expect(iiif_imgsvc.document.sidecar.image_state.current_state).to eq("succeeded")
+    end
+
     it "prioritizes settings thumbnail field" do
       expect(thumb_imgsvc.send(:gblsi_thumbnail_field?)).to be_truthy
     end

--- a/spec/services/image_service_spec.rb
+++ b/spec/services/image_service_spec.rb
@@ -24,7 +24,7 @@ describe GeoblacklightSidecarImages::ImageService do
     end
 
     it "returns image_url" do
-      expect(thumb_imgsvc.send(:image_url)).to eq "https://umedia.lib.umn.edu/sites/default/files/imagecache/square300/reference/562/image/jpeg/1089695.jpg"
+      expect(thumb_imgsvc.send(:image_url)).to eq "https://cdm16022.contentdm.oclc.org/utils/getthumbnail/collection/p16022coll206/id/133.jpg"
     end
 
     it "returns references if no settings thumbnail field value" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,37 @@
 # frozen_string_literal: true
 
+ENV["RAILS_ENV"] = "test"
+
 require "simplecov"
 SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
+
+SimpleCov.start "rails" do
+  # refuse_coverage_drop
+end
+
+require "database_cleaner"
+require "engine_cart"
+EngineCart.load_application!
+
+require "rspec/rails"
+require "capybara/rspec"
+require "selenium-webdriver"
+require "webdrivers"
 
 def json_data(filename)
   file_content = file_fixture("#{filename}.json").read
   JSON.parse(file_content, symbolize_names: true)
+end
+
+RSpec.configure do |config|
+  config.use_transactional_fixtures = false
+
+  config.before do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "simplecov"
 SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 
 SimpleCov.start "rails" do
+  # @TODO
   # refuse_coverage_drop
 end
 


### PR DESCRIPTION
Fixes #32 

Updates the GBL Sidecar Images plugin to:

* Work with Rails 7 correctly (declares our correct active_storage.variant_processor).
* Fixes Faraday namespace issue
* Adds a spec to test that harvesting actually can succeed
* Updates local dev/test to use same rake tasks as GBL proper (see below)

---

To run Solr and test the application, you can use the same rake tasks as GeoBlacklight.

Run Solr via:
`RAILS_ENV=test bundle exec geoblacklight:solr`

And then you can run the test suite via:
`RAILS_ENV=test bundle exec rake ci`