### PR TITLE
Fix GBLv3 Support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,7 +28,7 @@ jobs:
         ruby_version: ["3.0","2.7"]
         rails_version: [7.0.4.2, 6.1.7.2]
         bundler_version: [2.1.1]
-        faraday_version: ['>= 2', '~> 1.0']
+        faraday_version: ['~> 1.0']
 
     name: test ruby ${{ matrix.ruby_version }} / rails ${{ matrix.rails_version }} / faraday ${{ matrix.faraday_version }}
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,14 +10,22 @@ on:
 jobs:
   linter:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bundler_version: [2.1.1]
+        faraday_version: ['~> 1.0']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7
+    - name: Install bundler
+      run: gem install bundler -v ${{ matrix.bundler_version }}
     - name: Install dependencies
-      run: bundle install
+      run: bundle _${{ matrix.bundler_version }}_ install
+      env:
+        FARADAY_VERSION: ${{ matrix.faraday_version }}
     - name: Run linter
       run: bundle exec standardrb
 

--- a/app/services/geoblacklight_sidecar_images/image_service.rb
+++ b/app/services/geoblacklight_sidecar_images/image_service.rb
@@ -128,7 +128,7 @@ module GeoblacklightSidecarImages
       return nil unless uri.scheme.include?("http")
 
       conn = Faraday.new(url: uri.normalize.to_s) do |b|
-        b.use Geoblacklight::FaradayMiddleware::FollowRedirects
+        b.use FaradayMiddleware::FollowRedirects
         b.adapter :net_http
       end
 

--- a/geoblacklight_sidecar_images.gemspec
+++ b/geoblacklight_sidecar_images.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "faraday", ">= 1.0"
-  s.add_dependency "geoblacklight", ">= 3.3"
+  s.add_dependency "geoblacklight", "~> 3.3"
   s.add_dependency "image_processing", "~> 1.6"
   s.add_dependency "mimemagic", "~> 0.3"
   s.add_dependency "mini_magick", "~> 4.9.4"

--- a/lib/tasks/geoblacklight_sidecar_images_tasks.rake
+++ b/lib/tasks/geoblacklight_sidecar_images_tasks.rake
@@ -36,7 +36,7 @@ namespace :gblsci do
       results.docs.each do |document|
         sleep(1)
         begin
-          GeoblacklightSidecarImages::StoreImageJob.perform_later(document.id)
+          GeoblacklightSidecarImages::StoreImageJob.perform_later(document['layer_slug_s'])
         rescue Blacklight::Exceptions::RecordNotFound
           next
         end

--- a/lib/tasks/geoblacklight_sidecar_images_tasks.rake
+++ b/lib/tasks/geoblacklight_sidecar_images_tasks.rake
@@ -36,7 +36,7 @@ namespace :gblsci do
       results.docs.each do |document|
         sleep(1)
         begin
-          GeoblacklightSidecarImages::StoreImageJob.perform_later(document['layer_slug_s'])
+          GeoblacklightSidecarImages::StoreImageJob.perform_later(document["layer_slug_s"])
         rescue Blacklight::Exceptions::RecordNotFound
           next
         end

--- a/spec/fixtures/files/esri-tiled_map_layer.json
+++ b/spec/fixtures/files/esri-tiled_map_layer.json
@@ -1,20 +1,20 @@
 {
   "geoblacklight_version": "1.0",
-  "dc_description_s": "This map shows the Soil Survey Geographic (SSURGO) by the United States Department of Agriculture's Natural Resources Conservation Service. It also shows data that was developed by the National Cooperative Soil Survey and supersedes the State Soil Geographic (STATSGO) dataset published in 1994. SSURGO digitizing duplicates the original soil survey maps. This level of mapping is designed for use by landowners, townships, and county natural resource planning and management. The user should be knowledgeable of soils data and their characteristics. The smallest scale map shows the Global Soil Regions map by the United States Department of Agriculture’s Natural Resources Conservation Service.",
+  "dc_description_s": "This map presents a digital version of the Operational Navigation Charts (ONC) at 1:1,000,000-scale, produced by the US National Geospatial-Intelligence Agency (NGA). The map includes over 200 charts across the world, excluding parts of North America, Europe, Asia, and Oceania where charts are not publicly available. For more information on this map, including the terms of use, visit us online.",
   "dc_format_s": "GeoTIFF",
-  "dc_identifier_s": "test-soil-survey-map",
+  "dc_identifier_s": "esri-tiled-map-layer",
   "dc_language_s": "English",
   "dc_publisher_s": "United States Department of Agriculture, Natural Resources Conservation Service",
   "dc_rights_s": "Public",
-  "dc_title_s": "Soil Survey Geographic (SSURGO)",
+  "dc_title_s": "Specialty/World_Navigation_Charts (MapServer)",
   "dc_type_s": "Dataset",
-  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#TiledMapLayer\": \"http://services.arcgisonline.com/arcgis/rest/services/Specialty/Soil_Survey_Map/MapServer\"}",
+  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#TiledMapLayer\": \"https://services.arcgisonline.com/arcgis/rest/services/Specialty/World_Navigation_Charts/MapServer\"}",
   "dct_temporal_sm": [
-    "2010"
+    "2013"
   ],
   "dct_provenance_s": "NYU",
-  "layer_slug_s": "nyu-test-soil-survey-map",
-  "layer_id_s": "test-soil-survey_map",
+  "layer_slug_s": "esri-tiled-map-layer",
+  "layer_id_s": "esri-tiled-map-layer",
   "layer_geom_type_s": "Raster",
   "layer_modified_dt": "2015-06-16T00:59:49Z",
   "solr_geom": "ENVELOPE(-129.4956, -64.4393, 48.6336, 21.8079)",

--- a/spec/services/image_service_spec.rb
+++ b/spec/services/image_service_spec.rb
@@ -3,25 +3,68 @@
 require "rails_helper"
 
 describe GeoblacklightSidecarImages::ImageService do
+  # Dynamic Map Layer
+  let(:dynamic_map_document) { SolrDocument.new(json_data("esri-dynamic-layer-all-layers")) }
+  let(:dynamic_map_imgsvc) { described_class.new(dynamic_map_document) }
+
+  # IIIF
   let(:iiif_document) { SolrDocument.new(json_data("umich_iiif_jpg")) }
   let(:iiif_imgsvc) { described_class.new(iiif_document) }
-  let(:wms_document) { SolrDocument.new(json_data("esri-wms-layer")) }
+  
+  # Image Map Layer
+  let(:image_map_document) { SolrDocument.new(json_data("esri-image-map-layer")) }
+  let(:image_map_imgsvc) { described_class.new(image_map_document) }
+
+  # WMS
+  let(:wms_document) { SolrDocument.new(json_data("actual-polygon1")) }
   let(:wms_imgsvc) { described_class.new(wms_document) }
+  
+  # Thumbnail
   let(:thumb_document) { SolrDocument.new(json_data("umn_solr_thumb")) }
   let(:thumb_imgsvc) { described_class.new(thumb_document) }
-  let(:map_document) { SolrDocument.new(json_data("b1g_thumbnail")) }
-  let(:map_imgsvc) { described_class.new(map_document) }
-
-  # @TODO: bdcbcd3e-f6db-4ee4-b7b7-d75fe35f1d92 - Michigan State - thumbnail_path_ss
+  
+  # Tiled Map Layer
+  let(:tiled_map_document) { SolrDocument.new(json_data("esri-tiled_map_layer")) }
+  let(:tiled_map_imgsvc) { described_class.new(tiled_map_document) }
 
   describe "#store" do
     it "responds to store" do
       expect(iiif_imgsvc).to respond_to(:store)
     end
 
-    it "stores an image" do
+    it "stores a Dynamic Map Layer" do
+      # Doc: 90f14ff4-1359-4beb-b931-5cb41d20ab90
+      dynamic_map_imgsvc.store
+      expect(dynamic_map_imgsvc.document.sidecar.image_state.current_state).to eq("succeeded")
+    end
+
+    it "stores a IIIF image" do
+      # Doc: 3ffb1f2e-d617-4361-bc2b-49d9ad270cad
       iiif_imgsvc.store
       expect(iiif_imgsvc.document.sidecar.image_state.current_state).to eq("succeeded")
+    end
+
+    it "stores an Image Map Layer" do
+      # Doc: 32653ed6-8d83-4692-8a06-bf13ffe2c018
+      image_map_imgsvc.store
+      expect(image_map_imgsvc.document.sidecar.image_state.current_state).to eq("succeeded")
+    end
+
+    it "stores a Thumbnail" do
+      thumb_imgsvc.store
+      expect(thumb_imgsvc.document.sidecar.image_state.current_state).to eq("succeeded")
+    end
+
+    it "stores a Tiled Map Layer" do
+      # Doc: esri-tiled-map-layer
+      tiled_map_imgsvc.store
+      expect(tiled_map_imgsvc.document.sidecar.image_state.current_state).to eq("succeeded")
+    end
+
+    it "stores a WMS image" do
+      # Doc: tufts-cambridgegrid100-04
+      wms_imgsvc.store
+      expect(wms_imgsvc.document.sidecar.image_state.current_state).to eq("succeeded")
     end
 
     it "prioritizes settings thumbnail field" do
@@ -37,12 +80,12 @@ describe GeoblacklightSidecarImages::ImageService do
     end
 
     it "returns references without a settings thumbnail field value" do
-      pending "MIT fixture is not working."
+      skip "MIT fixture is not working."
       expect(wms_imgsvc.send(:image_url)).to include "wms"
     end
 
     it "returns no service_url when settings thumbnail field" do
-      expect(map_imgsvc.send(:service_url)).to be_falsey
+      expect(thumb_imgsvc.send(:service_url)).to be_falsey
     end
   end
 

--- a/spec/services/image_service_spec.rb
+++ b/spec/services/image_service_spec.rb
@@ -10,7 +10,7 @@ describe GeoblacklightSidecarImages::ImageService do
   # IIIF
   let(:iiif_document) { SolrDocument.new(json_data("umich_iiif_jpg")) }
   let(:iiif_imgsvc) { described_class.new(iiif_document) }
-  
+
   # Image Map Layer
   let(:image_map_document) { SolrDocument.new(json_data("esri-image-map-layer")) }
   let(:image_map_imgsvc) { described_class.new(image_map_document) }
@@ -18,11 +18,11 @@ describe GeoblacklightSidecarImages::ImageService do
   # WMS
   let(:wms_document) { SolrDocument.new(json_data("actual-polygon1")) }
   let(:wms_imgsvc) { described_class.new(wms_document) }
-  
+
   # Thumbnail
   let(:thumb_document) { SolrDocument.new(json_data("umn_solr_thumb")) }
   let(:thumb_imgsvc) { described_class.new(thumb_document) }
-  
+
   # Tiled Map Layer
   let(:tiled_map_document) { SolrDocument.new(json_data("esri-tiled_map_layer")) }
   let(:tiled_map_imgsvc) { described_class.new(tiled_map_document) }


### PR DESCRIPTION
* Pins GBL to v3
* Fixes Faraday namespace issue
* Fixes StoreImageJob document.id issue
* Fixes ESRI TileMapLayer fixture
* Adds tests that check each ImageService subclass can succeed

Fixes #35

----

TODOs after this PR:

* Cut release v0.9.1
* Create a releases-3.X branch
* Develop branch will move to Aardvark
* Cut release v0.10.0 with initial GBLv4 Aardvark support