### PR TITLE
Update GitHub Actions workflow to use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -70,7 +70,7 @@ jobs:
         ENGINE_CART_RAILS_OPTIONS: '--skip-git --skip-listen --skip-spring --skip-keeps --skip-action-cable --skip-coffee --skip-test'
         SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/blacklight-core
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: coverage

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "logger"
 require "rails"
 begin
   require "bundler/setup"

--- a/spec/fixtures/files/esri-dynamic-layer-all-layers.json
+++ b/spec/fixtures/files/esri-dynamic-layer-all-layers.json
@@ -40,7 +40,7 @@
   "dcat_bbox": "ENVELOPE(-91.513518, -87.495214, 42.508348,  36.969972)",
   "dct_accessRights_s": "Public",
   "dct_format_s": "Shapefile",
-  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#DynamicMapLayer\":\"http://data.isgs.illinois.edu/arcgis/rest/services/Geology/Glacial_Boundaries/MapServer\",\"http://schema.org/url\":\"https://clearinghouse.isgs.illinois.edu/data/geology/glacial-boundaries\",\"http://schema.org/downloadUrl\":[{\"label\":\"Shapefile\",\"url\":\"https://clearinghouse.isgs.illinois.edu/sites/clearinghouse.isgs/files/Clearinghouse/data/ISGS/Geology/zips/IL_Glacial_Bndys_Py.zip\"}]}",
+  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#DynamicMapLayer\":\"https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/MapServer\",\"http://schema.org/url\":\"https://clearinghouse.isgs.illinois.edu/data/geology/glacial-boundaries\",\"http://schema.org/downloadUrl\":[{\"label\":\"Shapefile\",\"url\":\"https://clearinghouse.isgs.illinois.edu/sites/clearinghouse.isgs/files/Clearinghouse/data/ISGS/Geology/zips/IL_Glacial_Bndys_Py.zip\"}]}",
   "gbl_mdModified_dt": "2018-08-02T17:00:40Z",
   "gbl_mdVersion_s": "Aardvark",
   "dct_isPartOf_sm": "illinois-collection-illinois-geospatial-data-clearinghouse"

--- a/spec/fixtures/files/esri-image-map-layer.json
+++ b/spec/fixtures/files/esri-image-map-layer.json
@@ -45,7 +45,7 @@
   ],
   "dct_accessRights_s": "Public",
   "dct_format_s": "GeoTIFF",
-  "dct_references_s": "{\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\",\"http://schema.org/downloadUrl\":[{\"label\":\"GeoTIFF\",\"url\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabash_topo_27.tif.zip\"}],\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://mapsweb.lib.purdue.edu/arcgis/rest/services/Purdue/wabashtopo/ImageServer\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"http://64.90.181.107/geonetwork/srv/api/records/32653ed6-8d83-4692-8a06-bf13ffe2c018/formatters/xml\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"https://mapsweb.lib.purdue.edu/wabashriver/\",\"http://schema.org/downloadUrl\":[{\"label\":\"GeoTIFF\",\"url\":\"https://mapsweb.lib.purdue.edu/datasets/Wabash1929/wabash_topo_27.tif.zip\"}],\"urn:x-esri:serviceType:ArcGIS#ImageMapLayer\":\"https://sampleserver6.arcgisonline.com/arcgis/rest/services/CharlotteLAS/ImageServer\",\"http://www.isotc211.org/schemas/2005/gmd/\":\"http://64.90.181.107/geonetwork/srv/api/records/32653ed6-8d83-4692-8a06-bf13ffe2c018/formatters/xml\"}",
   "gbl_mdModified_dt": "2018-07-20T18:08:03Z",
   "gbl_mdVersion_s": "Aardvark",
   "dct_isPartOf_sm": "purdue-collection-purdue-georeferenced-imagery"

--- a/spec/fixtures/files/esri-tiled_map_layer.json
+++ b/spec/fixtures/files/esri-tiled_map_layer.json
@@ -31,7 +31,7 @@
   "dct_accessRights_s": "Public",
   "dct_format_s": "GeoTIFF",
   "gbl_wxsIdentifier_s": "esri-tiled-map-layer",
-  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#TiledMapLayer\":\"https://services.arcgisonline.com/arcgis/rest/services/Specialty/World_Navigation_Charts/MapServer\",\"http://schema.org/downloadUrl\":[]}",
+  "dct_references_s": "{\"urn:x-esri:serviceType:ArcGIS#TiledMapLayer\":\"https://sampleserver6.arcgisonline.com/arcgis/rest/services/SF311/MapServer\",\"http://schema.org/downloadUrl\":[]}",
   "gbl_mdModified_dt": "2015-06-16T00:59:49Z",
   "gbl_mdVersion_s": "Aardvark"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require "capybara/rspec"
 require "selenium-webdriver"
 require "webdrivers"
 
+require "logger"
 require "rails/all"
 require "blacklight"
 require "geoblacklight"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 ENV["RAILS_ENV"] ||= "test"
 
+require "logger"
+
 # require "simplecov"
 # SimpleCov.formatter = SimpleCov::Formatter::HTMLFormatter
 
@@ -15,9 +17,14 @@ require "capybara/rspec"
 require "selenium-webdriver"
 require "webdrivers"
 
-require "logger"
 require "rails/all"
 require "blacklight"
+blacklight_root = Gem.loaded_specs.fetch("blacklight").full_gem_path
+
+# Rails 7.1 does not reliably autoload these Blacklight concerns before the
+# EngineCart app boots, so load them explicitly for the test app.
+require File.join(blacklight_root, "app/controllers/concerns/blacklight/search_fields")
+require File.join(blacklight_root, "app/controllers/concerns/blacklight/controller")
 require "geoblacklight"
 require "geoblacklight_sidecar_images"
 

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -9,6 +9,16 @@ class TestAppGenerator < Rails::Generators::Base
   # into the test app, this generator will be run immediately
   # after setting up the application
 
+  def disable_include_all_helpers
+    return unless File.exist?("config/application.rb")
+
+    gsub_file(
+      "config/application.rb",
+      /(\s*config\.load_defaults\s+\d+\.\d+\n)/,
+      "\\1    config.action_controller.include_all_helpers = false\n"
+    )
+  end
+
   def add_gems
     gem "blacklight", "~> 7.0"
     gem "geoblacklight", ">= 3.0"


### PR DESCRIPTION
## Fix GitHub CI for Ruby 3.3 and Rails 7.1
### Summary
Updates CI to address artifact upload deprecation, Rails 7.1 boot issues, and failing image service specs caused by broken external endpoints.
### Changes
**1. GitHub Actions**
- Bump `actions/upload-artifact` from `v2` to `v4` to address deprecation.

**2. Logger load order (Rails 7.1 / Ruby 3.3)**
- Add `require "logger"` at the top of `Rakefile` and `spec/spec_helper.rb` so the stdlib logger is loaded before `database_cleaner` and Rails, fixing `NameError: uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger`.

**3. Rails 7.1 Blacklight helper autoload**
- Set `config.action_controller.include_all_helpers = false` in the generated EngineCart test app to avoid premature constantization of Blacklight helpers under Rails 7.1.
- Explicitly require Blacklight controller concerns (`search_fields`, `controller`) in `spec_helper` before `EngineCart.load_application!`.

**4. Image service fixture endpoints**
- Replace fixtures whose `dct_references_s` URLs return 400/500:
  - **Dynamic Map Layer** (Illinois ISGS, 500) → Esri sampleserver6 SF311 MapServer
  - **Image Map Layer** (Purdue, 400) → Esri sampleserver6 CharlotteLAS ImageServer
  - **Tiled Map Layer** (ArcGIS Online, 400) → Esri sampleserver6 SF311 MapServer
- All replacement URLs return 200 for `/info/thumbnail/thumbnail.png`.
### Testing
- CI passes for both `rails_version: 7.0.8.1` and `7.1.3.2` in the matrix.
- Full spec suite passes, including image service specs.

Fixes #46